### PR TITLE
fix 【展开】、【收缩】  bug 

### DIFF
--- a/src/filterMore.js
+++ b/src/filterMore.js
@@ -310,11 +310,13 @@ $.extend(String.prototype, {
                 });
 
                 searchCtl.html(strHTML);
-                $(".searchbox .searchbox-item").each(function (i) {
-                    var height = $(this).find(".filter_option").outerHeight();
-                    if (height <= 30) {
-                        $(this).find(".r").remove();
-                    }
+                $(settings.searchBoxs).each(function (i, item) {
+                    $("#" + item.id).each(function (i) {
+                        var height = $(this).find(".filter_option").outerHeight();
+                        if (height <= 30) {
+                            $(this).find(".r").remove();
+                        }
+                    });
                 });
                 //如果默认展开行数小于总条数
                 if (settings.expandRow < settings.searchBoxs.length) {


### PR DESCRIPTION
如果有一个页面多个filterMore，同时只有一个显示，其他隐藏。那么初始化其中一个时候会将其他初始化好的 【展开】按钮移除样式。
本次修改为只修改当前filterMore组件